### PR TITLE
Revert "Bump hilt_version from 2.44 to 2.46"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         lifecycle_version = "2.6.1"
         arch_version = "2.1.0"
         kotlin_version = "1.8.20"
-        ext.hilt_version = "2.46"
+        ext.hilt_version = "2.44"
         voyager_compose = '1.0.0-rc04'
         landscapist_version = "2.1.11"
         okhttp_bom_version = "4.10.0"


### PR DESCRIPTION
Reverts AbanobNageh/RecipeApp#3

I need to revert this because this causes a conflict between the Voyager library which still uses hilt version 2.44 and the updated version 2.46, this causes the app to crash as soon as it is open.