### PR TITLE
Update dependencies and bump compileSdk to 37

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -63,5 +63,6 @@ dependencies {
     androidTestImplementation libs.junit
     androidTestImplementation platform(libs.androidx.compose.bom)
     androidTestImplementation libs.androidx.compose.ui.test.junit4
+    debugImplementation platform(libs.androidx.compose.bom)
     debugImplementation libs.androidx.compose.ui.test.manifest
 }

--- a/build.gradle
+++ b/build.gradle
@@ -20,15 +20,7 @@ tasks.register('clean', Delete) {
 }
 
 ext._minSdkVersion = 23
-ext._compileSdkVersion = 36
+ext._compileSdkVersion = 37
 ext._targetSdkVersion = 36
 ext._versionCode = 1
 ext._versionName = "1.0.0"
-
-ext.compose_compiler_version = "1.5.15"
-ext.compose_bom_version = "2026.02.00"
-ext.lifecycle_version = '2.10.0'
-ext.kotlin_version = "2.3.10"
-ext.hilt_version = "2.59.1"
-ext.landscapist_version = '2.9.5'
-ext.okhttp_bom_version = "5.3.2"

--- a/dependencies/build.gradle
+++ b/dependencies/build.gradle
@@ -92,5 +92,6 @@ dependencies {
     androidTestImplementation libs.androidx.junit
     androidTestImplementation libs.androidx.espresso.core
     androidTestImplementation libs.androidx.compose.ui.test.junit4
+    debugImplementation platform(libs.androidx.compose.bom)
     debugImplementation libs.androidx.compose.ui.tooling
 }

--- a/feature-recipes/build.gradle
+++ b/feature-recipes/build.gradle
@@ -69,5 +69,6 @@ dependencies {
     androidTestImplementation platform(libs.androidx.compose.bom)
     androidTestImplementation libs.androidx.compose.ui.test.junit4
     androidTestImplementation libs.truth
+    debugImplementation platform(libs.androidx.compose.bom)
     debugImplementation libs.androidx.compose.ui.tooling
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,38 +1,34 @@
 [versions]
 activityCompose = "1.13.0"
-agp = "9.2.0"
+agp = "9.2.1"
 appcompat = "1.7.1"
-composeBom = "2026.03.01"
-composeUi = "1.10.6"
-coreKtx = "1.18.0"
-dagger = "2.59.2"
-daggerVersion = "2.59.2"
+composeBom = "2026.06.01"
+coreKtx = "1.19.0"
+dagger = "2.60"
+daggerVersion = "2.60"
 espressoCore = "3.7.0"
-foundation = "1.11.2"
-googleDevtoolsKsp = "2.3.6"
-gradle = "9.2.0"
+googleDevtoolsKsp = "2.3.9"
+gradle = "9.2.1"
 gradleToolchainsFoojayResolverConvention = "1.0.0"
 gson = "2.14.0"
-hiltNavigationFragment = "1.3.0"
-hiltCompiler = "1.3.0"
-jetbrainsKotlinPluginCompose = "2.3.20"
+hiltNavigationFragment = "1.4.0"
+hiltCompiler = "1.4.0"
+jetbrainsKotlinPluginCompose = "2.3.21"
 junit = "4.13.2"
 junitVersion = "1.3.0"
 kotlinGradlePlugin = "2.3.21"
-compileSdk = "36"
+compileSdk = "37"
 kotlinxCoroutinesAndroid = "1.11.0"
 kotlinxSerializationJson = "1.11.0"
-landscapistGlide = "2.9.8"
-landscapistPlaceholder = "2.9.6"
-lifecycleRuntimeKtx = "2.10.0"
+landscapistGlide = "2.10.0"
+landscapistPlaceholder = "2.10.0"
+lifecycleRuntimeKtx = "2.11.0"
 material = "1.14.0"
-materialIconsCore = "1.7.8"
-materialVersion = "1.10.6"
 mockitoCore = "5.23.0"
 navigationCompose = "2.9.8"
-hiltNavigationCompose = "1.3.0"
-okhttpBom = "5.3.2"
-okhttp = "5.3.2"
+hiltNavigationCompose = "1.4.0"
+okhttpBom = "5.4.0"
+okhttp = "5.4.0"
 retrofit = "3.0.0"
 truth = "1.4.5"
 
@@ -40,11 +36,11 @@ truth = "1.4.5"
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
-androidx-compose-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "foundation" }
-androidx-compose-material = { module = "androidx.compose.material:material", version.ref = "materialVersion" }
-androidx-compose-material-icons-core = { module = "androidx.compose.material:material-icons-core", version.ref = "materialIconsCore" }
-androidx-compose-ui = { module = "androidx.compose.ui:ui", version.ref = "composeUi" }
-androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "composeUi" }
+androidx-compose-foundation = { module = "androidx.compose.foundation:foundation" }
+androidx-compose-material = { module = "androidx.compose.material:material" }
+androidx-compose-material-icons-core = { module = "androidx.compose.material:material-icons-core" }
+androidx-compose-ui = { module = "androidx.compose.ui:ui" }
+androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "coreKtx" }
 androidx-espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "espressoCore" }
 androidx-junit = { module = "androidx.test.ext:junit", version.ref = "junitVersion" }
@@ -63,8 +59,8 @@ hilt-android-compiler = { group = "com.google.dagger", name = "hilt-android-comp
 hilt-android-gradle-plugin = { group = "com.google.dagger", name = "hilt-android-gradle-plugin", version.ref = "daggerVersion" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 kotlin-gradle-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlinGradlePlugin" }
-androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4", version.ref = "composeUi" }
-androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest", version.ref = "composeUi" }
+androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
+androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
 androidx-hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinxCoroutinesAndroid" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500


### PR DESCRIPTION
## Summary

Updates the app's dependencies to their latest stable versions, aligns the Compose setup around the BOM, and removes dead configuration. Verified locally with `assembleDebug`, `assembleDebugAndroidTest`, and `testDebugUnitTest` — all pass.

`compileSdk` is raised **36 → 37** (targetSdk stays at 36, so there is no runtime behavior change) because four of the updated libraries now require it.

## Version bumps

| Dependency | From → To |
|---|---|
| Gradle wrapper | 9.5.0 → 9.6.1 |
| Android Gradle Plugin | 9.2.0 → 9.2.1 |
| Compose BOM (drives UI/Foundation/Material) | 2026.03.01 → 2026.06.01 (Compose 1.11.4) |
| androidx.core:core-ktx | 1.18.0 → 1.19.0 |
| Hilt / Dagger | 2.59.2 → 2.60 |
| androidx.hilt (nav-fragment / nav-compose / compiler) | 1.3.0 → 1.4.0 |
| KSP | 2.3.6 → 2.3.9 |
| Kotlin Compose plugin | 2.3.20 → 2.3.21 (align with Kotlin 2.3.21) |
| landscapist (glide / placeholder) | 2.9.x → 2.10.0 |
| androidx.lifecycle | 2.10.0 → 2.11.0 |
| OkHttp (bom + okhttp) | 5.3.2 → 5.4.0 |

## Cleanup

- **Removed dead `ext.*_version` properties** from the top-level `build.gradle` — they were unused and had drifted out of sync with the version catalog.
- **Made Compose BOM-driven** — dropped the redundant explicit Compose versions (the BOM already pins the exact same 1.11.4 / icons 1.7.8) and added `debugImplementation platform(compose-bom)` where version-less Compose artifacts are declared, so resolution is guaranteed on every configuration.

## Not included

- **Kotlin 2.3.21 → 2.4.0** was intentionally held back: it requires a KSP build compatible with Kotlin 2.4.0, but the newest published KSP (2.3.9) still targets Kotlin 2.3.x, so bumping now would likely break Hilt's annotation processing. Worth revisiting once a 2.4.0-compatible KSP ships.

## Verification

```
./gradlew assembleDebug assembleDebugAndroidTest testDebugUnitTest  → BUILD SUCCESSFUL
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
